### PR TITLE
fix(docker): create log dir so Django starts in migration container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ RUN pip install --no-cache-dir -r requirements.txt gunicorn
 # Copy application code
 COPY . .
 
+# Create log directory required by production logging config
+RUN mkdir -p /var/log/maple-key
+
 # Collect static files
 RUN python manage.py collectstatic --noinput || true
 


### PR DESCRIPTION
## Summary
- Add `mkdir -p /var/log/maple-key` to Dockerfile
- Production `LOGGING` config uses `RotatingFileHandler` at `/var/log/maple-key/app.log`
- This directory was missing from the image → `django.setup()` crashed in migration gate → every backend deploy aborted with "MIGRATION FAILED"

## Test plan
- [ ] Backend deploy completes without FileNotFoundError
- [ ] Migration gate passes