### PR TITLE
Add CI quality gate: run tests on PRs to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: ci_user
+          POSTGRES_PASSWORD: ci_password
+          POSTGRES_DB: ci_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          DATABASE_URL: postgresql://ci_user:ci_password@localhost:5432/ci_db
+          SECRET_KEY: ci-secret-key-not-used-in-production
+          DEBUG: "True"
+          ALLOWED_HOSTS: "localhost,127.0.0.1"
+          CORS_ALLOWED_ORIGINS: http://localhost:5173
+          FRONTEND_URL: http://localhost:5173
+          RESEND_API_KEY: ci-resend-key
+          DEFAULT_FROM_EMAIL: ci@test.com
+        run: pytest tests/


### PR DESCRIPTION
## Summary
Adds a CI workflow that runs `pytest tests/` on every PR to `develop`.

Extracted the `test` job from `deploy.yml` (which gates `production`) and wired it to `develop` PRs. Same Postgres service, same env vars.

## To enforce as a required check
Go to **Settings → Branches → develop → branch protection rule** and enable:
- Require status checks to pass before merging
- Select the `test` status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)