### PR TITLE
v1.2 Phase 13-15: test suite improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: ci_user
+          POSTGRES_PASSWORD: ci_password
+          POSTGRES_DB: ci_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          DATABASE_URL: postgresql://ci_user:ci_password@localhost:5432/ci_db
+          SECRET_KEY: ci-secret-key-not-used-in-production
+          DEBUG: "True"
+          ALLOWED_HOSTS: "localhost,127.0.0.1"
+          CORS_ALLOWED_ORIGINS: http://localhost:5173
+          FRONTEND_URL: http://localhost:5173
+          RESEND_API_KEY: ci-resend-key
+          DEFAULT_FROM_EMAIL: ci@test.com
+        run: pytest tests/

--- a/tests/integration/custom_auth/test_google_exchange.py
+++ b/tests/integration/custom_auth/test_google_exchange.py
@@ -326,6 +326,13 @@ class TestGoogleExchangeInvitationFastPath:
         assert 'access_token' not in response.data
         assert 'refresh_token' not in response.data
 
+        # Regression guard: invitation must NOT be consumed when the is_approved guard blocks login
+        token.refresh_from_db()
+        assert token.is_used is False, (
+            'Invitation must not be marked used when is_approved=False blocks login. '
+            'mark_as_used() must only be called after the approval guard passes.'
+        )
+
     def test_expired_invitation_token_returns_400(self, api_client, school, management_user):
         """
         Expired invitation token: the view must return 400 before creating any user or JWT.

--- a/tests/integration/custom_auth/test_google_exchange.py
+++ b/tests/integration/custom_auth/test_google_exchange.py
@@ -15,6 +15,28 @@ import datetime
 User = get_user_model()
 
 
+def _build_google_mocks(email: str, google_id: str = 'google_id_default'):
+    """Module-level helper: build mock objects for Google token + userinfo endpoints."""
+    mock_token = MagicMock()
+    mock_token.status_code = 200
+    mock_token.json.return_value = {'access_token': 'google_access_token_mock'}
+
+    parts = email.split('@')[0].split('.')
+    given = parts[0].capitalize()
+    family = parts[1].capitalize() if len(parts) > 1 else 'User'
+
+    mock_userinfo = MagicMock()
+    mock_userinfo.status_code = 200
+    mock_userinfo.json.return_value = {
+        'email': email,
+        'given_name': given,
+        'family_name': family,
+        'id': google_id,
+        'name': f'{given} {family}',
+    }
+    return mock_token, mock_userinfo
+
+
 @pytest.fixture
 def api_client():
     return APIClient()
@@ -27,25 +49,7 @@ class TestGoogleExchangeEndpoint:
     URL = 'google_exchange'  # URL name registered in custom_auth/urls.py (Plan 02 wires this)
 
     def _mock_google_responses(self, email: str, google_id: str = 'google_id_123'):
-        """Helper: build mock objects for Google token + userinfo endpoints."""
-        mock_token = MagicMock()
-        mock_token.status_code = 200
-        mock_token.json.return_value = {'access_token': 'google_access_token_xyz'}
-
-        parts = email.split('@')[0].split('.')
-        given = parts[0].capitalize()
-        family = parts[1].capitalize() if len(parts) > 1 else 'User'
-
-        mock_userinfo = MagicMock()
-        mock_userinfo.status_code = 200
-        mock_userinfo.json.return_value = {
-            'email': email,
-            'given_name': given,
-            'family_name': family,
-            'id': google_id,
-            'name': f'{given} {family}',
-        }
-        return mock_token, mock_userinfo
+        return _build_google_mocks(email, google_id)
 
     def test_valid_exchange_existing_user_returns_200_with_tokens(self, api_client, school):
         """
@@ -225,25 +229,7 @@ class TestGoogleExchangeInvitationFastPath:
     URL = 'google_exchange'
 
     def _mock_google_responses(self, email: str, google_id: str = 'inv_google_id_001'):
-        """Helper: build mock objects for Google token + userinfo endpoints."""
-        mock_token = MagicMock()
-        mock_token.status_code = 200
-        mock_token.json.return_value = {'access_token': 'google_access_token_inv'}
-
-        parts = email.split('@')[0].split('.')
-        given = parts[0].capitalize()
-        family = parts[1].capitalize() if len(parts) > 1 else 'User'
-
-        mock_userinfo = MagicMock()
-        mock_userinfo.status_code = 200
-        mock_userinfo.json.return_value = {
-            'email': email,
-            'given_name': given,
-            'family_name': family,
-            'id': google_id,
-            'name': f'{given} {family}',
-        }
-        return mock_token, mock_userinfo
+        return _build_google_mocks(email, google_id)
 
     def _make_invitation(self, email, approver, user_type='teacher', expired=False, used=False):
         """Helper: create an ApprovedEmail + InvitationToken for the given email."""

--- a/tests/integration/custom_auth/test_google_exchange.py
+++ b/tests/integration/custom_auth/test_google_exchange.py
@@ -399,3 +399,7 @@ class TestGoogleExchangeInvitationFastPath:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert 'access_token' not in response.data
         assert User.objects.filter(email=wrong_email).count() == 0
+        assert User.objects.filter(email=email).count() == 0, (
+            'No user should be created for the invitation email when the Google '
+            'account email does not match.'
+        )


### PR DESCRIPTION
## Summary
- Add 3 test improvements: google exchange mock extracted to module level, invitation email mismatch 400 assertion, token.is_used False on 403 rejection path

## Changes
- `test: assert token.is_used is False on 403 rejection path`
- `test: assert no user created for invitation email on mismatch 400`
- `test: extract duplicate _mock_google_responses to module-level _build_google_mocks`

## Migrations
None — test-only changes.

## Test plan
- [ ] CI `test` job passes