### PR TITLE
fix(ci): rm /tmp/nginx.conf before write, accept 301 in health-cmd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,7 +225,7 @@ jobs:
             docker run -d \
               --name maple-key-backend \
               --restart unless-stopped \
-              --health-cmd "curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/api/auth/user/ | grep -qE '^(200|401)$'" \
+              --health-cmd "curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/api/auth/user/ | grep -qE '^(200|301|401)$'" \
               --health-interval 30s \
               --health-timeout 10s \
               --health-retries 3 \
@@ -299,6 +299,7 @@ jobs:
             docker stop nginx 2>/dev/null || true
             docker rm nginx 2>/dev/null || true
 
+            rm -rf /tmp/nginx.conf
             cat > /tmp/nginx.conf << 'EOF'
             server {
                 listen 80;


### PR DESCRIPTION
## Summary
Two deploy script fixes:
- `rm -rf /tmp/nginx.conf` before heredoc write — prevents failure when `/tmp/nginx.conf` is a directory from prior deploys
- health-cmd now accepts HTTP 301 (Django SSL redirect) in addition to 200/401

## Root cause
Previous deploy failed at nginx container swap because `/tmp/nginx.conf` existed as an empty directory on the VPS. Backend container started healthy but script exited 1 before nginx restart. Fixed manually post-deploy.

## Migrations
None.