### PR TITLE
Fix: reflect student pause on open teacher invoice batches

### DIFF
--- a/billing/views/management.py
+++ b/billing/views/management.py
@@ -935,6 +935,82 @@ def recurring_schedule_detail(request, student_id, schedule_id):
 # STUDENT PAUSE/RESUME ENDPOINTS
 # ============================================================================
 
+def reconcile_open_batches_for_student(student, school):
+    """
+    Re-sync FUTURE-dated, schedule-sourced lesson items for ``student`` in this
+    school's still-open (``draft``/``submitted``) teacher batches to match the
+    live, pause-aware projection (``get_scheduled_lessons_data``).
+
+    Called after a pause/resume change so teachers submit accurate invoices:
+    - PAUSE: future items now inside the pause window are no longer projected,
+      so they are DELETED from open batches.
+    - RESUME: future items the schedule projects again (and are missing) are
+      ADDED back to open batches.
+
+    Boundaries (billing integrity):
+    - Only ``draft`` and ``submitted`` batches are touched. ``approved`` batches
+      are locked (Lesson records / invoices already exist) and never change
+      (T-26-10).
+    - Only items with ``scheduled_date > today`` are touched. Lessons that have
+      already happened are billable and are never removed or resurrected.
+    - Only schedule-sourced items (``recurring_schedule`` set) are deleted;
+      manual one-offs are left alone.
+    """
+    today = date.today()
+    teacher_ids = list(
+        RecurringLessonsSchedule.objects.filter(
+            student=student, school=school, is_active=True
+        ).values_list('teacher_id', flat=True).distinct()
+    )
+    if not teacher_ids:
+        return
+
+    batches = MonthlyInvoiceBatch.objects.filter(
+        school=school,
+        status__in=['draft', 'submitted'],
+        teacher_id__in=teacher_ids,
+    )
+    for batch in batches:
+        projected = [
+            d for d in batch.get_scheduled_lessons_data()
+            if d['student'].id == student.id and d['scheduled_date'] > today
+        ]
+        projected_keys = {(d['scheduled_date'], d['start_time']) for d in projected}
+
+        # DELETE future, schedule-sourced items the live projection no longer
+        # includes (now inside the pause window).
+        future_items = BatchLessonItem.objects.filter(
+            batch=batch,
+            student=student,
+            scheduled_date__gt=today,
+            recurring_schedule__isnull=False,
+        )
+        for item in future_items:
+            if (item.scheduled_date, item.start_time) not in projected_keys:
+                item.delete()
+
+        # ADD future projected items missing from the batch (resume restores).
+        present_keys = {
+            (i.scheduled_date, i.start_time)
+            for i in BatchLessonItem.objects.filter(batch=batch, student=student)
+        }
+        for d in projected:
+            if (d['scheduled_date'], d['start_time']) not in present_keys:
+                BatchLessonItem.objects.create(
+                    batch=batch,
+                    student=student,
+                    scheduled_date=d['scheduled_date'],
+                    start_time=d['start_time'],
+                    duration=d['duration'],
+                    lesson_type=d['lesson_type'],
+                    teacher_rate=d['teacher_rate'],
+                    student_rate=d['student_rate'],
+                    status=d['status'],
+                    recurring_schedule=d['recurring_schedule'],
+                    is_one_off=False,
+                )
+
+
 @api_view(['POST'])
 @management_required
 def student_pause_lessons(request, student_id):
@@ -1011,6 +1087,10 @@ def student_pause_lessons(request, student_id):
         student=student,
         school=request.user.school,
     ).update(pause_start=pause_start, pause_end=pause_end)
+
+    # Reflect the change on open teacher batches so teachers submit accurate
+    # invoices: remove now-paused future lessons (and restore them on resume).
+    reconcile_open_batches_for_student(student, request.user.school)
 
     # Return updated schedules serialized
     schedules = RecurringLessonsSchedule.objects.filter(

--- a/tests/integration/billing/test_student_pause_api.py
+++ b/tests/integration/billing/test_student_pause_api.py
@@ -13,13 +13,16 @@ Covers:
 """
 
 import pytest
-from datetime import date
+from datetime import date, time
 from decimal import Decimal
 from django.urls import reverse
 from rest_framework.test import APIClient
 from rest_framework import status
 from django.contrib.auth import get_user_model
-from billing.models import RecurringLessonsSchedule, SchoolSettings
+from billing.models import (
+    RecurringLessonsSchedule, SchoolSettings,
+    MonthlyInvoiceBatch, BatchLessonItem,
+)
 
 User = get_user_model()
 
@@ -249,3 +252,150 @@ class TestStudentPauseEndpoint:
         response = authenticated_management_client.post(url, data, format='json')
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Cascade to open teacher batches — pause reflected on teacher invoices
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def student_one_wed_schedule(school, teacher_user, school_settings_fixture, db):
+    """Student with a SINGLE Wednesday 15:00 recurring schedule (deterministic)."""
+    student = User.objects.create_user(
+        email="cascade_student@test.com",
+        password="testpass123",
+        user_type="student",
+        first_name="Cascade",
+        last_name="Student",
+        school=school,
+        is_approved=True,
+    )
+    sched = RecurringLessonsSchedule.objects.create(
+        teacher=teacher_user,
+        student=student,
+        school=school,
+        day_of_week=2,
+        start_time="15:00",
+        duration=Decimal("1.0"),
+        lesson_type="in_person",
+        teacher_rate=Decimal("50.00"),
+        student_rate=Decimal("100.00"),
+        is_active=True,
+        start_date=date(2026, 1, 7),
+        created_by=teacher_user,
+    )
+    return student, sched
+
+
+def _make_batch(teacher, school, student, sched, month, year, status_value, dates):
+    batch = MonthlyInvoiceBatch.objects.create(
+        teacher=teacher, school=school, month=month, year=year, status=status_value,
+    )
+    for d in dates:
+        BatchLessonItem.objects.create(
+            batch=batch, student=student, scheduled_date=d, start_time=time(15, 0),
+            duration=Decimal("1.0"), lesson_type="in_person",
+            teacher_rate=Decimal("50.00"), student_rate=Decimal("100.00"),
+            status="confirmed", recurring_schedule=sched, is_one_off=False,
+        )
+    return batch
+
+
+@pytest.mark.django_db
+class TestPauseCascadeToOpenBatches:
+    """Pausing a student removes future in-window lessons from open teacher batches.
+
+    today is 2026-06-25, so all July dates are future. Boundaries: only
+    draft/submitted batches, only future schedule-sourced items (T-26-10).
+    """
+
+    def _url(self, student_id):
+        return reverse('student_pause_lessons', args=[student_id])
+
+    def _dates(self, batch, student):
+        return set(
+            BatchLessonItem.objects.filter(batch=batch, student=student)
+            .values_list('scheduled_date', flat=True)
+        )
+
+    def test_pause_removes_future_in_window_items_from_draft(
+        self, authenticated_management_client, student_one_wed_schedule, teacher_user, school
+    ):
+        student, sched = student_one_wed_schedule
+        batch = _make_batch(teacher_user, school, student, sched, 7, 2026, 'draft',
+                            [date(2026, 7, 8), date(2026, 7, 15)])
+        resp = authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': '2026-07-01', 'pause_end': '2026-07-31'}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        assert self._dates(batch, student) == set()  # both future July items removed
+
+    def test_pause_keeps_items_outside_window(
+        self, authenticated_management_client, student_one_wed_schedule, teacher_user, school
+    ):
+        student, sched = student_one_wed_schedule
+        batch = _make_batch(teacher_user, school, student, sched, 7, 2026, 'draft',
+                            [date(2026, 7, 8)])
+        # Pause August only -> July 8 is outside the window, must stay.
+        resp = authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': '2026-08-01', 'pause_end': '2026-08-31'}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        assert date(2026, 7, 8) in self._dates(batch, student)
+
+    def test_pause_keeps_past_items(
+        self, authenticated_management_client, student_one_wed_schedule, teacher_user, school
+    ):
+        student, sched = student_one_wed_schedule
+        # Past-dated item (before today 2026-06-25), inside an open-ended pause.
+        batch = _make_batch(teacher_user, school, student, sched, 6, 2026, 'draft',
+                            [date(2026, 6, 10)])
+        resp = authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': '2026-06-01', 'pause_end': None}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        assert date(2026, 6, 10) in self._dates(batch, student)  # already happened -> kept
+
+    def test_pause_does_not_touch_approved_batch(
+        self, authenticated_management_client, student_one_wed_schedule, teacher_user, school
+    ):
+        student, sched = student_one_wed_schedule
+        batch = _make_batch(teacher_user, school, student, sched, 7, 2026, 'approved',
+                            [date(2026, 7, 8)])
+        resp = authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': '2026-07-01', 'pause_end': '2026-07-31'}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        assert date(2026, 7, 8) in self._dates(batch, student)  # locked -> unchanged
+
+    def test_pause_cleans_submitted_batch(
+        self, authenticated_management_client, student_one_wed_schedule, teacher_user, school
+    ):
+        student, sched = student_one_wed_schedule
+        batch = _make_batch(teacher_user, school, student, sched, 7, 2026, 'submitted',
+                            [date(2026, 7, 8)])
+        resp = authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': '2026-07-01', 'pause_end': '2026-07-31'}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        assert date(2026, 7, 8) not in self._dates(batch, student)
+
+    def test_resume_readds_future_items_to_open_batch(
+        self, authenticated_management_client, student_one_wed_schedule, teacher_user, school
+    ):
+        student, sched = student_one_wed_schedule
+        batch = _make_batch(teacher_user, school, student, sched, 7, 2026, 'draft',
+                            [date(2026, 7, 8), date(2026, 7, 15)])
+        # Pause removes them...
+        authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': '2026-07-01', 'pause_end': '2026-07-31'}, format='json')
+        assert self._dates(batch, student) == set()
+        # ...resume restores the future July Wednesdays the schedule projects.
+        resp = authenticated_management_client.post(
+            self._url(student.id),
+            {'pause_start': None, 'pause_end': None}, format='json')
+        assert resp.status_code == status.HTTP_200_OK
+        restored = self._dates(batch, student)
+        assert date(2026, 7, 8) in restored
+        assert date(2026, 7, 15) in restored


### PR DESCRIPTION
Follow-up to phase 26 lesson pause. Bug from business UAT: after management pauses a student, the TEACHER invoice still showed the paused lessons (teacher batch reads persisted BatchLessonItem rows snapshotted at batch creation; pause only affected live projection).

## Fix (backend only, no migration)
reconcile_open_batches_for_student() called from the pause/resume endpoint:
- PAUSE: deletes future, in-window, schedule-sourced items from draft/submitted batches
- RESUME: re-adds future schedule-projected items to open batches
- Approved/billed batches never change (T-26-10); past-dated lessons never removed or resurrected

## Tests
6 new cascade integration tests (remove-future-in-window, keep-outside-window, keep-past, approved-untouched, submitted-cleaned, resume-readds). Local: 130 passed across batch/pause/invoice suites.